### PR TITLE
Separate reading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,10 @@ RUN git clone --recursive https://github.com/sorgerlab/indra.git && \
     cd $DIRPATH/indra/indra/benchmarks/assembly_eval/batch4 && \
     wget -nv http://sorger.med.harvard.edu/data/bachman/trips_reach_batch4.gz && \
     tar -xf trips_reach_batch4.gz
+
+# Install indra_reading
+RUN git clone https://github.com/indralab/indra_reading.git && \
+    cd indra_reading && \
+    git checkout $READING_BRANCH && \
+    echo $READING_BRANCH && \
+    pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM 292075781285.dkr.ecr.us-east-1.amazonaws.com/indra_deps:latest
 
 ARG BUILD_BRANCH
+ARG READING_BRANCH
 
 ENV DIRPATH /sw
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,7 +9,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build --build-arg BUILD_BRANCH=$BUILD_BRANCH -t $IMAGE_REPO_NAME:$IMAGE_TAG .
+      - docker build --build-arg BUILD_BRANCH=$BUILD_BRANCH --build-arg READING_BRANCH=$READING_BRANCH -t $IMAGE_REPO_NAME:$IMAGE_TAG .
       - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
   post_build:
     commands:


### PR DESCRIPTION
Update the dockerfile to adapt to https://github.com/sorgerlab/indra/pull/1039 in INDRA. This PR adds the `READING_BRANCH` build arg to specify a branch of [indra_reading](https://github.com/indralab/indra_reading) to use when building the docker.