### PR TITLE
Unify into a single build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ ENV LC_ALL en_US.UTF-8  #
 
 # Set environment variables
 ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
-ENV KAPPAPATH=$DIRPATH/KaSim
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # Install INDRA and dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     python -m protmapper.resources && \
     # Install BioNetGen
     wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" \
-        -O bionetgen.tar.gz -nv && \
+        -O bionetgen.tar.gz -nv
 
 # Install indra_reading
 RUN git clone https://github.com/indralab/indra_reading.git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     # Pre-build the bio ontology
     python -m indra.ontology.bio build && \
     # Download Adeft models
-    python -m adeft.download
+    python -m adeft.download && \
     # Download protmapper resources
     python -m protmapper.resources && \
     # Install BioNetGen

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,10 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     # Download protmapper resources
     python -m protmapper.resources && \
     # Install BioNetGen
+    cd $DIRPATH && \
     wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" \
-        -O bionetgen.tar.gz -nv
+        -O bionetgen.tar.gz -nv && \
+    tar xzf bionetgen.tar.gz
 
 # Install indra_reading
 RUN git clone https://github.com/indralab/indra_reading.git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,9 @@ RUN chmod +x $SPARSERPATH/save-semantics.sh && \
 # See https://github.com/docker-library/openjdk/issues/32
 ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
 ENV REACHDIR=$DIRPATH/reach
-ENV REACHPATH=$REACHDIR/reach-1.6.3-9ed6fe.jar
-ENV REACH_VERSION=1.6.3-9ed6fe
-ADD reach-1.6.3-9ed6fe.jar $REACHPATH
+ENV REACHPATH=$REACHDIR/reach-1.6.3-e48717.jar
+ENV REACH_VERSION=1.6.3-e48717
+ADD reach-1.6.3-e48717.jar $REACHPATH
 
 # MTI
 ADD mti_jars.zip $DIRPATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,58 @@
-FROM 292075781285.dkr.ecr.us-east-1.amazonaws.com/indra_deps:latest
+FROM ubuntu:focal
 
 ARG BUILD_BRANCH
 ARG READING_BRANCH
 
 WORKDIR $DIRPATH
 
+RUN apt-get update && \
+    # Install Java
+    apt-get install -y openjdk-8-jdk && \
+    # jnius-indra requires cython which requires gcc
+    apt-get install -y git wget zip unzip bzip2 gcc graphviz graphviz-dev \
+        pkg-config python3 python3-pip && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
+# Set default character encoding
+# See http://stackoverflow.com/questions/27931668/encoding-problems-when-running-an-app-in-docker-python-java-ruby-with-u/27931669
+# See http://stackoverflow.com/questions/39760663/docker-ubuntu-bin-sh-1-locale-gen-not-found
+RUN apt-get install -y locales && \
+    locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8  #
+
+# Set environment variables
+ENV DIRPATH /sw
+ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
+ENV KAPPAPATH=$DIRPATH/KaSim
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
+WORKDIR $DIRPATH
+
 # Install INDRA and dependencies
 RUN git clone https://github.com/sorgerlab/indra.git && \
-    pip list && \
-    echo $PYTHONPATH && \
     cd indra && \
     git checkout $BUILD_BRANCH && \
-    echo $BUILD_BRANCH && \
     git branch && \
     mkdir /root/.config && \
     mkdir /root/.config/indra && \
     echo "[indra]" > /root/.config/indra/config.ini && \
-    pip install -e . && \
+    # Install Python dependencies
+    pip install --upgrade pip && \
+    # Install cython first for pyjnius
+    pip install cython && \
+    pip install -e .[all] && \
+    pip uninstall -y enum34 && \
     # Pre-build the bio ontology
     python -m indra.ontology.bio build && \
     # Download Adeft models
     python -m adeft.download
+    # Download protmapper resources
+    python -m protmapper.resources && \
+    # Install BioNetGen
+    wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" \
+        -O bionetgen.tar.gz -nv && \
 
 # Install indra_reading
 RUN git clone https://github.com/indralab/indra_reading.git && \
@@ -28,3 +60,28 @@ RUN git clone https://github.com/indralab/indra_reading.git && \
     git checkout $READING_BRANCH && \
     echo $READING_BRANCH && \
     pip install -e .
+
+# Add and set up reading systems
+# ------------------------------
+# SPARSER
+ENV SPARSERPATH=$DIRPATH/sparser
+ADD r3.core $SPARSERPATH/r3.core
+ADD save-semantics.sh $SPARSERPATH/save-semantics.sh
+ADD version.txt $SPARSERPATH/version.txt
+RUN chmod +x $SPARSERPATH/save-semantics.sh && \
+    chmod +x $SPARSERPATH/r3.core
+
+# REACH
+# Default character encoding for Java in Docker is not UTF-8, which
+# leads to problems with REACH; so we set option
+# See https://github.com/docker-library/openjdk/issues/32
+ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
+ENV REACHDIR=$DIRPATH/reach
+ENV REACHPATH=$REACHDIR/reach-1.6.3-9ed6fe.jar
+ENV REACH_VERSION=1.6.3-9ed6fe
+ADD reach-1.6.3-9ed6fe.jar $REACHPATH
+
+# MTI
+ADD mti_jars.zip $DIRPATH
+RUN mkdir $DIRPATH/mti_jars && \
+    unzip $DIRPATH/mti_jars.zip -d $DIRPATH/mti_jars/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu:focal
 ARG BUILD_BRANCH
 ARG READING_BRANCH
 
+# Set working folder
+ENV DIRPATH /sw
 WORKDIR $DIRPATH
 
 RUN apt-get update && \
@@ -23,12 +25,9 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8  #
 
 # Set environment variables
-ENV DIRPATH /sw
 ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
 ENV KAPPAPATH=$DIRPATH/KaSim
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
-
-WORKDIR $DIRPATH
 
 # Install INDRA and dependencies
 RUN git clone https://github.com/sorgerlab/indra.git && \

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,6 +5,13 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - echo Getting Sparser
+      - aws s3 cp s3://bigmech/sparser_core/save-semantics.sh .
+      - aws s3 cp s3://bigmech/sparser_core/r3.core .
+      - aws s3 cp s3://bigmech/sparser_core/version.txt .
+      - echo Getting Reach
+      - aws s3 cp s3://bigmech/reach-1.6.3-9ed6fe.jar .
+      - aws s3 cp s3://bigmech/travis/mti_jars_v2.zip ./mti_jars.zip
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
       - aws s3 cp s3://bigmech/sparser_core/r3.core .
       - aws s3 cp s3://bigmech/sparser_core/version.txt .
       - echo Getting Reach
-      - aws s3 cp s3://bigmech/reach-1.6.3-9ed6fe.jar .
+      - aws s3 cp s3://bigmech/reach-1.6.3-e48717.jar .
       - aws s3 cp s3://bigmech/travis/mti_jars_v2.zip ./mti_jars.zip
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,6 +14,8 @@ phases:
       - aws s3 cp s3://bigmech/travis/mti_jars_v2.zip ./mti_jars.zip
   build:
     commands:
+      # This is to help with the pull rate limit
+      - docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PWD}"
       - echo Build started on `date`
       - echo Building the Docker image...
       - docker build --build-arg BUILD_BRANCH=$BUILD_BRANCH --build-arg READING_BRANCH=$READING_BRANCH -t $IMAGE_REPO_NAME:$IMAGE_TAG .


### PR DESCRIPTION
This PR removes the dependency on indra_deps_docker and implements the full build in a single Dockerfile here. Over time, the installation of dependencies has gotten easy enough that a separate dependencies build is not advantageous and doing a single build with this new process takes about the same amount of time as the old one.